### PR TITLE
Update lists

### DIFF
--- a/app/lists.go
+++ b/app/lists.go
@@ -2,7 +2,7 @@ package app
 
 import (
 	api "github.com/betasve/mstd/todoapi"
-	"github.com/olekukonko/tablewriter"
+	"github.com/olekukonko/tablewriter" // TODO: Replace with the abstracted ext/tablewriter
 	"os"
 	"reflect"
 	"strings"
@@ -36,7 +36,6 @@ func ListsIndex(columns []string) error {
 	}
 
 	printResults(lists, columns)
-
 	return nil
 }
 
@@ -49,6 +48,19 @@ func ListsCreate(name string, columns []string) error {
 	}
 
 	printResults(&[]api.ListsItem{*newList}, columns)
+
+	return nil
+}
+
+func ListsUpdate(id, name string, columns []string) error {
+	apiClient.SetToken(config.ClientAccessToken())
+	list, err := apiClient.ListsUpdate(id, name)
+
+	if err != nil {
+		return err
+	}
+
+	printResults(&[]api.ListsItem{*list}, columns)
 
 	return nil
 }

--- a/app/lists_test.go
+++ b/app/lists_test.go
@@ -1,6 +1,31 @@
 package app
 
-//
-// import (
-// 	"testing"
-// )
+import (
+	"github.com/betasve/mstd/conf"
+	api "github.com/betasve/mstd/todoapi"
+	apiTest "github.com/betasve/mstd/todoapi/todoapitest"
+	"testing"
+)
+
+func TestListIndex(test *testing.T) {
+	config = &conf.Config{}
+	_ = config.SetClientAccessToken("some")
+
+	apiTest.ListsIndexMockFn = func() (*[]api.ListsItem, error) {
+		return &[]api.ListsItem{
+			api.ListsItem{
+				Id:     "some-id",
+				Name:   "example name",
+				Owner:  true,
+				Shared: false,
+				System: "",
+			},
+		}, nil
+	}
+	apiClient = &apiTest.TodoApiMock{}
+	err := ListsIndex([]string{"display name"})
+	test.Log(err)
+	if err != nil {
+		test.Error(err)
+	}
+}

--- a/cmd/lists.go
+++ b/cmd/lists.go
@@ -26,7 +26,6 @@ var listsCmd = &cobra.Command{
 	Short: "Perform operations over To-Do Lists",
 	Long: `A command that provides the capability of listing, creating, editing
 	and deleting lists in your Microsoft To-Do account.`,
-	Run: func(cmd *cobra.Command, args []string) {},
 }
 
 func init() {

--- a/cmd/listsUpdate.go
+++ b/cmd/listsUpdate.go
@@ -1,0 +1,51 @@
+/*
+Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/betasve/mstd/app"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+var name string
+
+var listsUpdateCmd = &cobra.Command{
+	Use:   "update [ID]",
+	Short: "Update a list",
+	Long:  `Update a list's properties in To Do app`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if app.LoginNeeded() {
+			app.Login()
+		}
+
+		return app.ListsUpdate(
+			strings.Join(args, " "),
+			name,
+			parseStringToList(showColumns, ListSeparator, noSpaceLowerCase),
+		)
+	},
+}
+
+func init() {
+	listsCmd.AddCommand(listsUpdateCmd)
+	listsUpdateCmd.Flags().StringVarP(
+		&name,
+		"name", "", "",
+		"Set the name property of a list",
+	)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,7 @@ import (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "mstd",
+	Use:   "mstd", // TODO: Replace references of `mstd` with the value of args[0]
 	Short: "A CLI for Microsoft To Do",
 	Long: `This command line interface is for interacting with your account
 in Microsoft's To Do application https://todo.microsoft.com/tasks/.

--- a/ext/tablewriter/service.go
+++ b/ext/tablewriter/service.go
@@ -1,0 +1,10 @@
+package tablewriter
+
+// TODO: start stubbing "github.com/olekukonko/tablewriter" to be able use it
+// in the app through here and then test it properly
+
+var Client TableWriterService = TableWriter{}
+
+type TableWriterService interface{}
+
+type TableWriter struct{}

--- a/ext/tablewriter/tablewritertest/stubs.go
+++ b/ext/tablewriter/tablewritertest/stubs.go
@@ -1,0 +1,4 @@
+package tablewriter
+
+// TODO: Fill with tests at a later stage when we start using our
+// {TableWriterService} enabling testing its behavior

--- a/todoapi/todoapitest/stubs.go
+++ b/todoapi/todoapitest/stubs.go
@@ -16,12 +16,20 @@ var ListsCreateMockFn = func(n string) (*api.ListsItem, error) {
 	return &api.ListsItem{}, nil
 }
 
+var ListsUpdateMockFn = func(i, n string) (*api.ListsItem, error) {
+	return &api.ListsItem{}, nil
+}
+
 func (ta *TodoApiMock) ListsIndex() (*[]api.ListsItem, error) {
 	return ListsIndexMockFn()
 }
 
 func (ta *TodoApiMock) ListsCreate(name string) (*api.ListsItem, error) {
 	return ListsCreateMockFn(name)
+}
+
+func (ta *TodoApiMock) ListsUpdate(id, name string) (*api.ListsItem, error) {
+	return ListsUpdateMockFn(id, name)
 }
 
 func (ta *TodoApiMock) SetToken(token string) {


### PR DESCRIPTION
Introducing the functionality to update Lists' names (also setting a default Lists page size of 100). As it turns out, the current default in their (MS) api is 16 (:thinking: )